### PR TITLE
feats: 完善颜色拾取器的显示逻辑和增加选区外的遮罩

### DIFF
--- a/src/app/contextWrap.tsx
+++ b/src/app/contextWrap.tsx
@@ -41,6 +41,7 @@ export enum AppSettingsGroup {
     SystemNetwork = 'systemNetwork',
     FunctionChat = 'functionChat',
     FunctionTranslation = 'functionTranslation',
+    FunctionScreenshot = 'functionScreenshot',
 }
 
 export enum AppSettingsLanguage {
@@ -64,8 +65,6 @@ export type AppSettingsData = {
     [AppSettingsGroup.Screenshot]: {
         /** 选区控件样式 */
         controlNode: AppSettingsControlNode;
-        /** 选取窗口子元素 */
-        findChildrenElements: boolean;
     };
     [AppSettingsGroup.Cache]: {
         menuCollapsed: boolean;
@@ -101,6 +100,10 @@ export type AppSettingsData = {
     [AppSettingsGroup.FunctionTranslation]: {
         chatPrompt: string;
     };
+    [AppSettingsGroup.FunctionScreenshot]: {
+        /** 选取窗口子元素 */
+        findChildrenElements: boolean;
+    };
 };
 
 export const defaultAppSettingsData: AppSettingsData = {
@@ -111,7 +114,6 @@ export const defaultAppSettingsData: AppSettingsData = {
     },
     [AppSettingsGroup.Screenshot]: {
         controlNode: AppSettingsControlNode.Circle,
-        findChildrenElements: true,
     },
     [AppSettingsGroup.Cache]: {
         menuCollapsed: false,
@@ -143,6 +145,9 @@ export const defaultAppSettingsData: AppSettingsData = {
     },
     [AppSettingsGroup.FunctionTranslation]: {
         chatPrompt: defaultTranslationPrompt,
+    },
+    [AppSettingsGroup.FunctionScreenshot]: {
+        findChildrenElements: true,
     },
 };
 
@@ -347,15 +352,8 @@ const ContextWrapCore: React.FC<{ children: React.ReactNode }> = ({ children }) 
                     }
                 }
 
-                const findChildrenElements =
-                    typeof newSettings?.findChildrenElements === 'boolean'
-                        ? newSettings.findChildrenElements
-                        : (prevSettings?.findChildrenElements ??
-                          defaultAppSettingsData[group].findChildrenElements);
-
                 settings = {
                     controlNode,
-                    findChildrenElements,
                 };
             } else if (group === AppSettingsGroup.DrawToolbarKeyEvent) {
                 newSettings = newSettings as AppSettingsData[typeof group];
@@ -607,6 +605,21 @@ const ContextWrapCore: React.FC<{ children: React.ReactNode }> = ({ children }) 
                         typeof newSettings?.chatPrompt === 'string'
                             ? newSettings.chatPrompt
                             : (prevSettings?.chatPrompt ?? ''),
+                };
+            } else if (group === AppSettingsGroup.FunctionScreenshot) {
+                newSettings = newSettings as AppSettingsData[typeof group];
+                const prevSettings = appSettingsRef.current[group] as
+                    | AppSettingsData[typeof group]
+                    | undefined;
+
+                const findChildrenElements =
+                    typeof newSettings?.findChildrenElements === 'boolean'
+                        ? newSettings.findChildrenElements
+                        : (prevSettings?.findChildrenElements ??
+                          defaultAppSettingsData[group].findChildrenElements);
+
+                settings = {
+                    findChildrenElements,
                 };
             } else {
                 return defaultAppSettingsData[group];

--- a/src/app/contextWrap.tsx
+++ b/src/app/contextWrap.tsx
@@ -105,6 +105,8 @@ export type AppSettingsData = {
         findChildrenElements: boolean;
         /** 始终显示颜色选择器 */
         alwaysShowColorPicker: boolean;
+        /** 超出选区范围的元素透明度 */
+        beyondSelectRectElementOpacity: number;
     };
 };
 
@@ -151,6 +153,7 @@ export const defaultAppSettingsData: AppSettingsData = {
     [AppSettingsGroup.FunctionScreenshot]: {
         findChildrenElements: true,
         alwaysShowColorPicker: false,
+        beyondSelectRectElementOpacity: 100,
     },
 };
 
@@ -628,6 +631,11 @@ const ContextWrapCore: React.FC<{ children: React.ReactNode }> = ({ children }) 
                             ? newSettings.alwaysShowColorPicker
                             : (prevSettings?.alwaysShowColorPicker ??
                               defaultAppSettingsData[group].alwaysShowColorPicker),
+                    beyondSelectRectElementOpacity:
+                        typeof newSettings?.beyondSelectRectElementOpacity === 'number'
+                            ? Math.min(Math.max(newSettings.beyondSelectRectElementOpacity, 0), 100)
+                            : (prevSettings?.beyondSelectRectElementOpacity ??
+                              defaultAppSettingsData[group].beyondSelectRectElementOpacity),
                 };
             } else {
                 return defaultAppSettingsData[group];

--- a/src/app/contextWrap.tsx
+++ b/src/app/contextWrap.tsx
@@ -103,6 +103,8 @@ export type AppSettingsData = {
     [AppSettingsGroup.FunctionScreenshot]: {
         /** 选取窗口子元素 */
         findChildrenElements: boolean;
+        /** 始终显示颜色选择器 */
+        alwaysShowColorPicker: boolean;
     };
 };
 
@@ -148,6 +150,7 @@ export const defaultAppSettingsData: AppSettingsData = {
     },
     [AppSettingsGroup.FunctionScreenshot]: {
         findChildrenElements: true,
+        alwaysShowColorPicker: false,
     },
 };
 
@@ -620,6 +623,11 @@ const ContextWrapCore: React.FC<{ children: React.ReactNode }> = ({ children }) 
 
                 settings = {
                     findChildrenElements,
+                    alwaysShowColorPicker:
+                        typeof newSettings?.alwaysShowColorPicker === 'boolean'
+                            ? newSettings.alwaysShowColorPicker
+                            : (prevSettings?.alwaysShowColorPicker ??
+                              defaultAppSettingsData[group].alwaysShowColorPicker),
                 };
             } else {
                 return defaultAppSettingsData[group];

--- a/src/app/draw/components/colorPicker/index.tsx
+++ b/src/app/draw/components/colorPicker/index.tsx
@@ -81,33 +81,33 @@ const ColorPickerCore: React.FC<{
             return;
         }
 
-        let opacity = '0';
+        let opacity = '1';
 
         if (enableRef.current) {
-            opacity = '1';
-        }
+            if (!getAppSettings()[AppSettingsGroup.FunctionScreenshot].alwaysShowColorPicker) {
+                const selectRect = selectLayerActionRef.current?.getSelectRect();
+                if (selectRect) {
+                    const mouseX = mousePositionRef.current.mouseX * imageBuffer.monitorScaleFactor;
+                    const mouseY = mousePositionRef.current.mouseY * imageBuffer.monitorScaleFactor;
 
-        if (!getAppSettings()[AppSettingsGroup.FunctionScreenshot].alwaysShowColorPicker) {
-            const selectRect = selectLayerActionRef.current?.getSelectRect();
-            if (selectRect) {
-                const mouseX = mousePositionRef.current.mouseX * imageBuffer.monitorScaleFactor;
-                const mouseY = mousePositionRef.current.mouseY * imageBuffer.monitorScaleFactor;
+                    const tolerance = token.marginXXS;
 
-                const tolerance = token.marginXXS;
-
-                if (
-                    mouseX > selectRect.min_x - tolerance &&
-                    mouseX < selectRect.max_x + tolerance &&
-                    mouseY > selectRect.min_y - tolerance &&
-                    mouseY < selectRect.max_y + tolerance
-                ) {
-                    opacity = '1';
+                    if (
+                        mouseX > selectRect.min_x - tolerance &&
+                        mouseX < selectRect.max_x + tolerance &&
+                        mouseY > selectRect.min_y - tolerance &&
+                        mouseY < selectRect.max_y + tolerance
+                    ) {
+                        opacity = '1';
+                    } else {
+                        opacity = '0';
+                    }
                 } else {
                     opacity = '0';
                 }
-            } else {
-                opacity = '0';
             }
+        } else {
+            opacity = '0';
         }
 
         colorPickerRef.current.style.opacity = opacity;

--- a/src/app/draw/components/selectLayer/extra.ts
+++ b/src/app/draw/components/selectLayer/extra.ts
@@ -69,6 +69,9 @@ export const drawSelectRect = (
     darkMode: boolean,
     scaleFactor: number,
     screenshotType: ScreenshotType,
+    drawElementMask?: {
+        imageData: ImageData;
+    },
 ) => {
     const { min_x: rectMinX, min_y: rectMinY, max_x: rectMaxX, max_y: rectMaxY } = selectRect;
     const rectWidth = rectMaxX - rectMinX;
@@ -84,6 +87,10 @@ export const drawSelectRect = (
     const fillColor = getMaskBackgroundColor(darkMode);
 
     canvasContext.clearRect(0, 0, monitorWidth, monitorHeight);
+
+    if (drawElementMask) {
+        canvasContext.putImageData(drawElementMask.imageData, 0, 0);
+    }
 
     canvasContext.fillStyle = fillColor;
     canvasContext.fillRect(0, 0, monitorWidth, monitorHeight);

--- a/src/app/draw/components/selectLayer/index.tsx
+++ b/src/app/draw/components/selectLayer/index.tsx
@@ -59,7 +59,9 @@ const SelectLayerCore: React.FC<SelectLayerProps> = ({ actionRef }) => {
     const [getAppSettings] = useStateSubscriber(
         AppSettingsPublisher,
         useCallback((settings: AppSettingsData) => {
-            setFindChildrenElements(settings[AppSettingsGroup.Screenshot].findChildrenElements);
+            setFindChildrenElements(
+                settings[AppSettingsGroup.FunctionScreenshot].findChildrenElements,
+            );
         }, []),
     );
     const [getScreenshotType] = useStateSubscriber(ScreenshotTypePublisher, undefined);
@@ -568,7 +570,9 @@ const SelectLayerCore: React.FC<SelectLayerProps> = ({ actionRef }) => {
         },
         {
             preventDefault: true,
-            enabled: isEnable && getAppSettings()[AppSettingsGroup.Screenshot].findChildrenElements,
+            enabled:
+                isEnable &&
+                getAppSettings()[AppSettingsGroup.FunctionScreenshot].findChildrenElements,
         },
     );
 

--- a/src/app/draw/page.tsx
+++ b/src/app/draw/page.tsx
@@ -21,7 +21,7 @@ import {
 } from './extra';
 import { DrawToolbar, DrawToolbarActionType } from './components/drawToolbar';
 import { BaseLayerEventActionType } from './components/baseLayer';
-import { ColorPicker } from './components/colorPicker';
+import { ColorPicker, ColorPickerActionType } from './components/colorPicker';
 import { HistoryContext, withCanvasHistory } from './components/historyContext';
 import { withStatePublisher } from '@/hooks/useStatePublisher';
 import { useStateSubscriber } from '@/hooks/useStateSubscriber';
@@ -69,6 +69,7 @@ const DrawPageCore: React.FC = () => {
     const drawCacheLayerActionRef = useRef<DrawCacheLayerActionType | undefined>(undefined);
     const selectLayerActionRef = useRef<SelectLayerActionType | undefined>(undefined);
     const drawToolbarActionRef = useRef<DrawToolbarActionType | undefined>(undefined);
+    const colorPickerActionRef = useRef<ColorPickerActionType | undefined>(undefined);
     const [isFixed, setIsFixed] = useState(false);
     const fixedImageActionRef = useRef<FixedImageActionType | undefined>(undefined);
     const ocrBlocksActionRef = useRef<OcrBlocksActionType | undefined>(undefined);
@@ -399,6 +400,7 @@ const DrawPageCore: React.FC = () => {
             drawCacheLayerActionRef,
             ocrBlocksActionRef,
             fixedImageActionRef,
+            colorPickerActionRef,
         };
     }, [finishCapture]);
 
@@ -466,6 +468,7 @@ const DrawPageCore: React.FC = () => {
                             onCopyColor={() => {
                                 finishCapture();
                             }}
+                            actionRef={colorPickerActionRef}
                         />
                         <StatusBar />
 

--- a/src/app/draw/types.ts
+++ b/src/app/draw/types.ts
@@ -7,6 +7,7 @@ import { MousePosition } from '@/utils/mousePosition';
 import { DrawCacheLayerActionType } from './components/drawCacheLayer/extra';
 import { OcrBlocksActionType } from './components/ocrBlocks';
 import { FixedImageActionType } from './components/fixedImage';
+import { ColorPickerActionType } from './components/colorPicker';
 
 export enum CaptureStep {
     // 选择阶段
@@ -71,6 +72,7 @@ export type DrawContextType = {
     drawCacheLayerActionRef: React.RefObject<DrawCacheLayerActionType | undefined>;
     ocrBlocksActionRef: React.RefObject<OcrBlocksActionType | undefined>;
     fixedImageActionRef: React.RefObject<FixedImageActionType | undefined>;
+    colorPickerActionRef: React.RefObject<ColorPickerActionType | undefined>;
 };
 
 export const DrawContext = React.createContext<DrawContextType>({
@@ -84,4 +86,5 @@ export const DrawContext = React.createContext<DrawContextType>({
     drawCacheLayerActionRef: { current: undefined },
     ocrBlocksActionRef: { current: undefined },
     fixedImageActionRef: { current: undefined },
+    colorPickerActionRef: { current: undefined },
 });

--- a/src/app/menuLayout.tsx
+++ b/src/app/menuLayout.tsx
@@ -441,6 +441,18 @@ const MenuLayoutCore: React.FC<{ children: React.ReactNode }> = ({ children }) =
                         label: intl.formatMessage({ id: 'menu.settings.functionSettings' }),
                         tabs: [
                             {
+                                key: 'screenshotSettings',
+                                label: intl.formatMessage({
+                                    id: 'settings.functionSettings.screenshotSettings',
+                                }),
+                            },
+                            {
+                                key: 'translationSettings',
+                                label: intl.formatMessage({
+                                    id: 'settings.functionSettings.translationSettings',
+                                }),
+                            },
+                            {
                                 key: 'functionSettings',
                                 label: intl.formatMessage({
                                     id: 'settings.functionSettings.chatSettings',

--- a/src/app/settings/functionSettings/page.tsx
+++ b/src/app/settings/functionSettings/page.tsx
@@ -11,6 +11,7 @@ import { IconLabel } from '@/components/iconLable';
 import { ResetSettingsButton } from '@/components/resetSettingsButton';
 import ProForm, {
     ProFormList,
+    ProFormSlider,
     ProFormSwitch,
     ProFormText,
     ProFormTextArea,
@@ -95,7 +96,7 @@ export default function SystemSettings() {
                         );
                     }}
                     submitter={false}
-                    layout="horizontal"
+                    layout="vertical"
                 >
                     <Row gutter={token.padding}>
                         <Col span={12}>
@@ -112,8 +113,38 @@ export default function SystemSettings() {
                                 name="alwaysShowColorPicker"
                                 layout="horizontal"
                                 label={
-                                    <FormattedMessage id="settings.functionSettings.screenshotSettings.alwaysShowColorPicker" />
+                                    <IconLabel
+                                        label={
+                                            <FormattedMessage id="settings.functionSettings.screenshotSettings.alwaysShowColorPicker" />
+                                        }
+                                        tooltipTitle={
+                                            <FormattedMessage id="settings.functionSettings.screenshotSettings.alwaysShowColorPicker.tip" />
+                                        }
+                                    />
                                 }
+                            />
+                        </Col>
+
+                        <Col span={12}>
+                            <ProFormSlider
+                                label={
+                                    <IconLabel
+                                        label={
+                                            <FormattedMessage id="settings.functionSettings.screenshotSettings.beyondSelectRectElementOpacity" />
+                                        }
+                                        tooltipTitle={
+                                            <FormattedMessage id="settings.functionSettings.screenshotSettings.beyondSelectRectElementOpacity.tip" />
+                                        }
+                                    />
+                                }
+                                name="beyondSelectRectElementOpacity"
+                                min={0}
+                                max={100}
+                                step={1}
+                                marks={{
+                                    0: '0%',
+                                    100: '100%',
+                                }}
                             />
                         </Col>
                     </Row>

--- a/src/app/settings/functionSettings/page.tsx
+++ b/src/app/settings/functionSettings/page.tsx
@@ -28,6 +28,7 @@ export default function SystemSettings() {
     const { updateAppSettings } = useContext(AppSettingsActionContext);
     const [functionForm] = Form.useForm<AppSettingsData[AppSettingsGroup.FunctionChat]>();
     const [translationForm] = Form.useForm<AppSettingsData[AppSettingsGroup.FunctionTranslation]>();
+    const [screenshotForm] = Form.useForm<AppSettingsData[AppSettingsGroup.FunctionScreenshot]>();
 
     const [appSettingsLoading, setAppSettingsLoading] = useState(true);
     useAppSettingsLoad(
@@ -50,13 +51,62 @@ export default function SystemSettings() {
                 ) {
                     functionForm.setFieldsValue(settings[AppSettingsGroup.FunctionChat]);
                 }
+
+                if (
+                    preSettings === undefined ||
+                    preSettings[AppSettingsGroup.FunctionScreenshot] !==
+                        settings[AppSettingsGroup.FunctionScreenshot]
+                ) {
+                    screenshotForm.setFieldsValue(settings[AppSettingsGroup.FunctionScreenshot]);
+                }
             },
-            [functionForm, translationForm],
+            [functionForm, translationForm, screenshotForm],
         ),
         true,
     );
     return (
         <ContentWrap>
+            <GroupTitle
+                id="screenshotSettings"
+                extra={
+                    <ResetSettingsButton
+                        title={
+                            <FormattedMessage id="settings.functionSettings.screenshotSettings" />
+                        }
+                        appSettingsGroup={AppSettingsGroup.FunctionScreenshot}
+                    />
+                }
+            >
+                <FormattedMessage id="settings.functionSettings.screenshotSettings" />
+            </GroupTitle>
+
+            <Spin spinning={appSettingsLoading}>
+                <ProForm
+                    form={screenshotForm}
+                    onValuesChange={(_, values) => {
+                        updateAppSettings(
+                            AppSettingsGroup.FunctionScreenshot,
+                            values,
+                            true,
+                            true,
+                            true,
+                            true,
+                            false,
+                        );
+                    }}
+                    submitter={false}
+                    layout="horizontal"
+                >
+                    <ProFormSwitch
+                        name="findChildrenElements"
+                        layout="horizontal"
+                        label={
+                            <FormattedMessage id="settings.functionSettings.screenshotSettings.findChildrenElements" />
+                        }
+                    />
+                </ProForm>
+            </Spin>
+
             <GroupTitle
                 id="translationSettings"
                 extra={

--- a/src/app/settings/functionSettings/page.tsx
+++ b/src/app/settings/functionSettings/page.tsx
@@ -97,13 +97,26 @@ export default function SystemSettings() {
                     submitter={false}
                     layout="horizontal"
                 >
-                    <ProFormSwitch
-                        name="findChildrenElements"
-                        layout="horizontal"
-                        label={
-                            <FormattedMessage id="settings.functionSettings.screenshotSettings.findChildrenElements" />
-                        }
-                    />
+                    <Row gutter={token.padding}>
+                        <Col span={12}>
+                            <ProFormSwitch
+                                name="findChildrenElements"
+                                layout="horizontal"
+                                label={
+                                    <FormattedMessage id="settings.functionSettings.screenshotSettings.findChildrenElements" />
+                                }
+                            />
+                        </Col>
+                        <Col span={12}>
+                            <ProFormSwitch
+                                name="alwaysShowColorPicker"
+                                layout="horizontal"
+                                label={
+                                    <FormattedMessage id="settings.functionSettings.screenshotSettings.alwaysShowColorPicker" />
+                                }
+                            />
+                        </Col>
+                    </Row>
                 </ProForm>
             </Spin>
 

--- a/src/app/settings/generalSettings/page.tsx
+++ b/src/app/settings/generalSettings/page.tsx
@@ -160,23 +160,6 @@ export default function GeneralSettings() {
                                 </Select>
                             </Form.Item>
                         </Col>
-                        <Col span={12}>
-                            <Form.Item
-                                name="findChildrenElements"
-                                label={
-                                    <IconLabel
-                                        label={
-                                            <FormattedMessage id="settings.findChildrenElements" />
-                                        }
-                                    />
-                                }
-                                valuePropName="checked"
-                                required={false}
-                                rules={[{ required: true }]}
-                            >
-                                <Switch />
-                            </Form.Item>
-                        </Col>
                     </Row>
                 </Spin>
             </Form>

--- a/src/messages/zhHans/settings.ts
+++ b/src/messages/zhHans/settings.ts
@@ -80,9 +80,9 @@ export const settings = {
         '如果你需要将该模型用于翻译，不建议开启此选项',
     'settings.functionSettings.screenshotSettings': '截图设置',
     'settings.functionSettings.screenshotSettings.findChildrenElements': '查找窗口子元素',
-    'settings.functionSettings.screenshotSettings.alwaysShowColorPicker': '始终显示颜色选择器',
+    'settings.functionSettings.screenshotSettings.alwaysShowColorPicker': '始终显示颜色拾取器',
     'settings.functionSettings.screenshotSettings.alwaysShowColorPicker.tip':
-        '超出选区范围时，保持显示颜色选择器',
+        '超出选区范围时，保持显示颜色拾取器',
     'settings.functionSettings.screenshotSettings.beyondSelectRectElementOpacity':
         '超出选区范围的元素透明度',
     'settings.functionSettings.screenshotSettings.beyondSelectRectElementOpacity.tip':

--- a/src/messages/zhHans/settings.ts
+++ b/src/messages/zhHans/settings.ts
@@ -80,4 +80,7 @@ export const settings = {
         '如果你需要将该模型用于翻译，不建议开启此选项',
     'settings.functionSettings.screenshotSettings': '截图设置',
     'settings.functionSettings.screenshotSettings.findChildrenElements': '查找窗口子元素',
+    'settings.functionSettings.screenshotSettings.alwaysShowColorPicker': '始终显示颜色选择器',
+    'settings.functionSettings.screenshotSettings.alwaysShowColorPicker.tip':
+        '超出选区范围时，任然显示颜色选择器',
 };

--- a/src/messages/zhHans/settings.ts
+++ b/src/messages/zhHans/settings.ts
@@ -82,5 +82,9 @@ export const settings = {
     'settings.functionSettings.screenshotSettings.findChildrenElements': '查找窗口子元素',
     'settings.functionSettings.screenshotSettings.alwaysShowColorPicker': '始终显示颜色选择器',
     'settings.functionSettings.screenshotSettings.alwaysShowColorPicker.tip':
-        '超出选区范围时，任然显示颜色选择器',
+        '超出选区范围时，保持显示颜色选择器',
+    'settings.functionSettings.screenshotSettings.beyondSelectRectElementOpacity':
+        '超出选区范围的元素透明度',
+    'settings.functionSettings.screenshotSettings.beyondSelectRectElementOpacity.tip':
+        '选定截图区域后，绘制的元素在超出选区范围时显示的透明度',
 };

--- a/src/messages/zhHans/settings.ts
+++ b/src/messages/zhHans/settings.ts
@@ -78,4 +78,6 @@ export const settings = {
     'settings.functionSettings.chatSettings.apiConfig.supportThinking': '支持推理',
     'settings.functionSettings.chatSettings.apiConfig.supportThinking.tip':
         '如果你需要将该模型用于翻译，不建议开启此选项',
+    'settings.functionSettings.screenshotSettings': '截图设置',
+    'settings.functionSettings.screenshotSettings.findChildrenElements': '查找窗口子元素',
 };


### PR DESCRIPTION
1. [feats: 移动查找窗口子元素到功能设置页面](https://github.com/mg-chao/snow-shot/commit/3ad344557c7ef94102f41b3f01099e1cfd7d9bbf)
2. [feats: 增加颜色选择器是否始终显示配置](https://github.com/mg-chao/snow-shot/commit/5eea5de252e43d90fbc6c2c74e6bfb0d67d9a419)
3. [feats: 超出选取元素遮罩](https://github.com/mg-chao/snow-shot/commit/c0361504d979bd753018a90e7f8fd683936e94f3)