### PR TITLE
perf: 滚动截图优化

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,7 +25,6 @@ pub fn run() {
         ocr_instance: Some(OcrLite::new()),
     };
     let ocr_instance = Mutex::new(ocr_instance);
-    let scroll_screenshot_service = Mutex::new(services::ScrollScreenshotService::new());
     let video_record_service = Mutex::new(services::VideoRecordService::new());
 
     let enigo_instance = Enigo::new(&Settings::default()).unwrap();
@@ -33,6 +32,9 @@ pub fn run() {
 
     let ui_elements = Mutex::new(UIElements::new());
     let auto_start_hide_window = Mutex::new(false);
+
+    let scroll_screenshot_service = Mutex::new(services::ScrollScreenshotService::new());
+    let scroll_screenshot_image_service = Mutex::new(services::ScrollScreenshotImageService::new());
 
     let mut app_builder = tauri::Builder::default().plugin(tauri_plugin_os::init());
 
@@ -89,6 +91,7 @@ pub fn run() {
         .manage(enigo_instance)
         .manage(scroll_screenshot_service)
         .manage(video_record_service)
+        .manage(scroll_screenshot_image_service)
         .invoke_handler(tauri::generate_handler![
             screenshot::capture_current_monitor,
             screenshot::get_window_elements,
@@ -121,6 +124,7 @@ pub fn run() {
             scroll_screenshot::scroll_screenshot_get_image_data,
             scroll_screenshot::scroll_screenshot_init,
             scroll_screenshot::scroll_screenshot_capture,
+            scroll_screenshot::scroll_screenshot_handle_image,
             scroll_screenshot::scroll_screenshot_save_to_file,
             scroll_screenshot::scroll_screenshot_save_to_clipboard,
             scroll_screenshot::scroll_screenshot_get_size,

--- a/src-tauri/src/os/ui_automation/windows.rs
+++ b/src-tauri/src/os/ui_automation/windows.rs
@@ -420,9 +420,15 @@ impl UIElements {
         );
 
         let mut element_rect = Self::normalize_rect(element_rect);
+
         let window_rect = self
             .window_rect_map
-            .get(&element_level)
+            .get(
+                &self
+                    .window_index_level_map
+                    .get(&element_level.window_index)
+                    .unwrap_or(&element_level),
+            )
             .unwrap_or(&element_rect)
             .clone();
         if Self::beyond_rect(element_rect, window_rect) {

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,7 +1,8 @@
+mod scroll_screenshot_image_service;
 mod scroll_screenshot_service;
 pub use scroll_screenshot_service::ScrollDirection;
 pub use scroll_screenshot_service::ScrollImageList;
-pub use scroll_screenshot_service::ScrollOffset;
 pub use scroll_screenshot_service::ScrollScreenshotService;
 mod video_record_service;
-pub use video_record_service::{VideoFormat, VideoRecordService, VideoRecordState};
+pub use scroll_screenshot_image_service::ScrollScreenshotImageService;
+pub use video_record_service::{VideoFormat, VideoRecordService};

--- a/src-tauri/src/services/scroll_screenshot_image_service.rs
+++ b/src-tauri/src/services/scroll_screenshot_image_service.rs
@@ -1,0 +1,48 @@
+use image::DynamicImage;
+use std::collections::VecDeque;
+
+use crate::services::ScrollImageList;
+
+pub struct ScrollScreenshotImage {
+    pub image: DynamicImage,
+    pub direction: ScrollImageList,
+}
+
+/**
+ * 将截图和处理截图分开处理
+ * 通过短时间内多次截图来提高滚动截图的响应速度和可靠性
+ */
+pub struct ScrollScreenshotImageService {
+    image_queue: VecDeque<ScrollScreenshotImage>,
+}
+
+impl ScrollScreenshotImageService {
+    pub fn new() -> Self {
+        Self {
+            image_queue: VecDeque::new(),
+        }
+    }
+
+    /**
+     * 将截图添加到待处理队列尾部
+     */
+    pub fn push_image(&mut self, image: DynamicImage, direction: ScrollImageList) {
+        self.image_queue
+            .push_back(ScrollScreenshotImage { image, direction });
+    }
+
+    /**
+     * 从队列头开始获取连续相同direction的图片，遇到不同direction则终止
+     */
+    pub fn pop_image(&mut self) -> Option<ScrollScreenshotImage> {
+        return self.image_queue.pop_front();
+    }
+
+    pub fn has_image(&self) -> bool {
+        !self.image_queue.is_empty()
+    }
+
+    pub fn image_count(&self) -> usize {
+        self.image_queue.len()
+    }
+}

--- a/src-tauri/src/services/scroll_screenshot_service.rs
+++ b/src-tauri/src/services/scroll_screenshot_service.rs
@@ -120,6 +120,8 @@ pub struct ScrollScreenshotService {
     pub image_scroll_side_size: i32,
     /// 是否启用 fast12 算法进行角点检测
     pub enable_corner_fast12: Option<bool>,
+    /// 是否尝试回滚
+    pub try_rollback: bool,
 }
 
 impl ScrollScreenshotService {
@@ -216,6 +218,7 @@ impl ScrollScreenshotService {
             top_image_ann_index: ScrollIndex::new(0),
             bottom_image_ann_index: ScrollIndex::new(0),
             enable_corner_fast12: None,
+            try_rollback: false,
         }
     }
 
@@ -237,6 +240,7 @@ impl ScrollScreenshotService {
         corner_threshold: u8,
         descriptor_patch_size: usize,
         min_size_delta: i32,
+        try_rollback: bool,
     ) {
         self.top_image_list.clear();
         self.bottom_image_list.clear();
@@ -252,6 +256,7 @@ impl ScrollScreenshotService {
         self.bottom_image_index_size = 0;
         self.top_image_ann_index = ScrollIndex::new(self.get_descriptor_size());
         self.bottom_image_ann_index = ScrollIndex::new(self.get_descriptor_size());
+        self.try_rollback = try_rollback;
 
         let image_scale_side_size;
         if self.current_direction == ScrollDirection::Vertical {
@@ -785,7 +790,7 @@ impl ScrollScreenshotService {
         offsets = first_offsets;
 
         // 如果第一个方向没有找到匹配，尝试另一个方向
-        if offsets.is_none() {
+        if offsets.is_none() && self.try_rollback {
             let second_index = if scroll_image_list == ScrollImageList::Top {
                 &self.bottom_image_ann_index
             } else {

--- a/src/app/draw/components/drawToolbar/components/keyEventWrap/extra.ts
+++ b/src/app/draw/components/drawToolbar/components/keyEventWrap/extra.ts
@@ -14,6 +14,7 @@ export type KeyEventComponentValue = KeyEventValue & {
 export enum KeyEventKey {
     MoveTool = 'moveTool',
     SelectTool = 'selectTool',
+    LockDrawTool = 'lockDrawTool',
     RectTool = 'rectTool',
     EllipseTool = 'ellipseTool',
     ArrowTool = 'arrowTool',
@@ -56,6 +57,10 @@ export const defaultDrawToolbarKeyEventSettings: Record<KeyEventKey, KeyEventVal
     },
     [KeyEventKey.SelectTool]: {
         hotKey: 'V',
+        unique: true,
+    },
+    [KeyEventKey.LockDrawTool]: {
+        hotKey: 'Ctrl+L',
         unique: true,
     },
     [KeyEventKey.RectTool]: {

--- a/src/app/draw/components/drawToolbar/components/keyEventWrap/extra.ts
+++ b/src/app/draw/components/drawToolbar/components/keyEventWrap/extra.ts
@@ -60,7 +60,7 @@ export const defaultDrawToolbarKeyEventSettings: Record<KeyEventKey, KeyEventVal
         unique: true,
     },
     [KeyEventKey.LockDrawTool]: {
-        hotKey: 'Ctrl+L',
+        hotKey: 'Ctrl+Alt+L',
         unique: true,
     },
     [KeyEventKey.RectTool]: {

--- a/src/app/draw/components/drawToolbar/components/toolButton/index.tsx
+++ b/src/app/draw/components/drawToolbar/components/toolButton/index.tsx
@@ -14,6 +14,7 @@ const ToolButtonCore: React.FC<{
     onClick: () => void;
     drawState: DrawState;
     extraDrawState?: DrawState[];
+    enableState?: boolean;
     disable?: boolean;
     confirmTip?: React.ReactNode;
     hotkeyScope?: HotkeysScope;
@@ -24,6 +25,7 @@ const ToolButtonCore: React.FC<{
     onClick,
     drawState: propDrawState,
     extraDrawState,
+    enableState,
     disable,
     confirmTip,
     hotkeyScope,
@@ -34,11 +36,13 @@ const ToolButtonCore: React.FC<{
         (drawState: DrawState) => {
             setButtonType(
                 getButtonTypeByState(
-                    drawState === propDrawState || (extraDrawState?.includes(drawState) ?? false),
+                    drawState === propDrawState ||
+                        enableState ||
+                        (extraDrawState?.includes(drawState) ?? false),
                 ),
             );
         },
-        [propDrawState, extraDrawState],
+        [propDrawState, enableState, extraDrawState],
     );
 
     useStateSubscriber(DrawStatePublisher, updateButtonType);

--- a/src/app/draw/components/selectLayer/index.tsx
+++ b/src/app/draw/components/selectLayer/index.tsx
@@ -138,8 +138,9 @@ const SelectLayerCore: React.FC<SelectLayerProps> = ({ actionRef }) => {
     const setSelectState = useCallback(
         (state: SelectState) => {
             if (
-                selectStateRef.current === SelectState.Auto &&
-                (state === SelectState.Selected || state === SelectState.Manual)
+                state === SelectState.Selected &&
+                (selectStateRef.current === SelectState.Manual ||
+                    selectStateRef.current === SelectState.Auto)
             ) {
                 recoveryWindowZOrder().then(() => {
                     getCurrentWindow().setFocus();

--- a/src/app/fixedContent/components/ocrResult/index.tsx
+++ b/src/app/fixedContent/components/ocrResult/index.tsx
@@ -233,6 +233,7 @@ export const OcrResult: React.FC<{
                 const ocrResult = await ocrDetect(
                     await imageBlob.arrayBuffer(),
                     monitorInfo.monitor_scale_factor,
+                    getAppSettings()[AppSettingsGroup.SystemScreenshot].ocrDetectAngle,
                 );
 
                 const ocrAfterAction =
@@ -284,12 +285,13 @@ export const OcrResult: React.FC<{
                 const ocrResult = await ocrDetect(
                     await imageBlob.arrayBuffer(),
                     monitorScaleFactorRef.current,
+                    getAppSettings()[AppSettingsGroup.SystemScreenshot].ocrDetectAngle,
                 );
                 updateOcrTextElements(ocrResult);
                 onOcrDetect?.(ocrResult);
             }
         },
-        [onOcrDetect, updateOcrTextElements],
+        [getAppSettings, onOcrDetect, updateOcrTextElements],
     );
 
     useImperativeHandle(

--- a/src/app/fullScreenDraw/components/drawCore/extra.tsx
+++ b/src/app/fullScreenDraw/components/drawCore/extra.tsx
@@ -136,6 +136,8 @@ export enum DrawState {
     Blur = 10,
     // 橡皮擦
     Eraser = 11,
+    // 锁定
+    Lock = 12,
     // 撤销
     Undo = 101,
     // 重做

--- a/src/app/settings/functionSettings/page.tsx
+++ b/src/app/settings/functionSettings/page.tsx
@@ -218,9 +218,9 @@ export default function SystemSettings() {
                         <Col span={12}>
                             <ProFormSwitch
                                 label={
-                                    <FormattedMessage id="settings.functionSettings.screenshotSettings.autoOcrAfterFixed" />
+                                    <FormattedMessage id="settings.functionSettings.screenshotSettings.shortcutCanleTip" />
                                 }
-                                name="autoOcrAfterFixed"
+                                name="shortcutCanleTip"
                                 layout="horizontal"
                             />
                         </Col>
@@ -228,9 +228,9 @@ export default function SystemSettings() {
                         <Col span={12}>
                             <ProFormSwitch
                                 label={
-                                    <FormattedMessage id="settings.functionSettings.screenshotSettings.shortcutCanleTip" />
+                                    <FormattedMessage id="settings.functionSettings.screenshotSettings.lockDrawTool" />
                                 }
-                                name="shortcutCanleTip"
+                                name="lockDrawTool"
                                 layout="horizontal"
                             />
                         </Col>
@@ -274,6 +274,16 @@ export default function SystemSettings() {
                                 label={
                                     <FormattedMessage id="settings.functionSettings.screenshotSettings.ocrCopyText" />
                                 }
+                            />
+                        </Col>
+
+                        <Col span={12}>
+                            <ProFormSwitch
+                                label={
+                                    <FormattedMessage id="settings.functionSettings.screenshotSettings.autoOcrAfterFixed" />
+                                }
+                                name="autoOcrAfterFixed"
+                                layout="horizontal"
                             />
                         </Col>
                     </Row>

--- a/src/app/settings/systemSettings/page.tsx
+++ b/src/app/settings/systemSettings/page.tsx
@@ -27,7 +27,7 @@ import { FormattedMessage } from 'react-intl';
 import { ContentWrap } from '@/components/contentWrap';
 import { IconLabel } from '@/components/iconLable';
 import { ResetSettingsButton } from '@/components/resetSettingsButton';
-import ProForm, { ProFormSelect, ProFormSlider } from '@ant-design/pro-form';
+import ProForm, { ProFormSelect, ProFormSlider, ProFormSwitch } from '@ant-design/pro-form';
 import { openPath } from '@tauri-apps/plugin-opener';
 import { AntdContext } from '@/components/globalLayoutExtra';
 import { clearAllAppStore } from '@/utils/appStore';
@@ -275,11 +275,31 @@ export default function SystemSettings() {
                                 options={[
                                     {
                                         label: (
-                                            <FormattedMessage id="settings.systemSettings.screenshotSettings.ocrModel.paddleOcr" />
+                                            <FormattedMessage id="settings.systemSettings.screenshotSettings.ocrModel.rapidOcrV4" />
                                         ),
-                                        value: OcrModel.PaddleOcr,
+                                        value: OcrModel.RapidOcrV4,
+                                    },
+                                    {
+                                        label: (
+                                            <FormattedMessage id="settings.systemSettings.screenshotSettings.ocrModel.rapidOcrV5" />
+                                        ),
+                                        value: OcrModel.RapidOcrV5,
                                     },
                                 ]}
+                            />
+                        </Col>
+
+                        <Col span={12}>
+                            <ProFormSwitch
+                                label={
+                                    <IconLabel
+                                        label={
+                                            <FormattedMessage id="settings.systemSettings.screenshotSettings.ocrDetectAngle" />
+                                        }
+                                    />
+                                }
+                                name="ocrDetectAngle"
+                                valuePropName="checked"
                             />
                         </Col>
                     </Row>
@@ -401,6 +421,24 @@ export default function SystemSettings() {
                 >
                     <Row gutter={token.margin}>
                         <Col span={12}>
+                            <ProFormSwitch
+                                label={
+                                    <IconLabel
+                                        label={
+                                            <FormattedMessage id="settings.systemSettings.scrollScreenshotSettings.tryRollback" />
+                                        }
+                                        tooltipTitle={
+                                            <FormattedMessage id="settings.systemSettings.scrollScreenshotSettings.tryRollback.tip" />
+                                        }
+                                    />
+                                }
+                                name="tryRollback"
+                            />
+                        </Col>
+                    </Row>
+
+                    <Row gutter={token.margin}>
+                        <Col span={12}>
                             <ProFormSlider
                                 label={
                                     <IconLabel
@@ -420,6 +458,7 @@ export default function SystemSettings() {
                                     0: '0',
                                     255: '255',
                                 }}
+                                layout="vertical"
                             />
                         </Col>
                         <Col span={12}>
@@ -442,6 +481,7 @@ export default function SystemSettings() {
                                     0: '0.1',
                                     1: '1',
                                 }}
+                                layout="vertical"
                             />
                         </Col>
                         <Col span={12}>
@@ -464,6 +504,7 @@ export default function SystemSettings() {
                                     64: '64',
                                     1024: '1024',
                                 }}
+                                layout="vertical"
                             />
                         </Col>
                         <Col span={12}>
@@ -486,6 +527,7 @@ export default function SystemSettings() {
                                     64: '64',
                                     1024: '1024',
                                 }}
+                                layout="vertical"
                             />
                         </Col>
                         <Col span={12}>
@@ -508,6 +550,7 @@ export default function SystemSettings() {
                                     8: '8',
                                     128: '128',
                                 }}
+                                layout="vertical"
                             />
                         </Col>
                     </Row>

--- a/src/commands/ocr.ts
+++ b/src/commands/ocr.ts
@@ -18,17 +18,20 @@ export interface OcrDetectResult {
 export const ocrDetect = async (
     data: ArrayBuffer | Uint8Array,
     scaleFactor: number,
+    detectAngle: boolean,
 ): Promise<OcrDetectResult> => {
     const result = await invoke<string>('ocr_detect', data, {
         headers: {
             'x-scale-factor': scaleFactor.toFixed(3),
+            'x-detect-angle': detectAngle ? 'true' : 'false',
         },
     });
     return JSON.parse(result) as OcrDetectResult;
 };
 
 export enum OcrModel {
-    PaddleOcr = 'PaddleOcr',
+    RapidOcrV4 = 'RapidOcrV4',
+    RapidOcrV5 = 'RapidOcrV5',
 }
 
 export const ocrInit = async (model: OcrModel): Promise<void> => {

--- a/src/messages/zhHans/draw.ts
+++ b/src/messages/zhHans/draw.ts
@@ -34,6 +34,7 @@ export const draw = {
     'draw.rgb': 'RGB ({r}, {g}, {b})',
     'draw.moveTool': '移动',
     'draw.selectTool': '选择',
+    'draw.lockDrawTool': '锁定绘制工具',
     'draw.rectTool': '矩形',
     'draw.diamondTool': '菱形',
     'draw.ellipseTool': '椭圆',

--- a/src/messages/zhHans/settings.ts
+++ b/src/messages/zhHans/settings.ts
@@ -95,6 +95,7 @@ export const settings = {
         '选定截图区域后，绘制的元素在超出选区范围时显示的透明度',
     'settings.functionSettings.screenshotSettings.autoOcrAfterFixed': '固定屏幕后自动 OCR',
     'settings.functionSettings.screenshotSettings.shortcutCanleTip': '快捷键取消截图提示',
+    'settings.functionSettings.screenshotSettings.lockDrawTool': '锁定绘制工具',
     'settings.functionSettings.screenshotSettings.ocrAfterAction': 'OCR 后自动执行',
     'settings.functionSettings.screenshotSettings.ocrAfterAction.none': '无操作',
     'settings.functionSettings.screenshotSettings.ocrAfterAction.copyText': '复制文本',
@@ -143,6 +144,9 @@ export const settings = {
     'settings.functionSettings.videoRecordSettings.hwaccel': '启用硬件加速',
     'settings.functionSettings.videoRecordSettings.saveDirectory': '保存目录',
     'settings.systemSettings.scrollScreenshotSettings': '滚动截图',
+    'settings.systemSettings.scrollScreenshotSettings.tryRollback': '匹配两侧图片',
+    'settings.systemSettings.scrollScreenshotSettings.tryRollback.tip':
+        '滚动截图存在上下、左右两种情况，滚动时会根据滚动方向匹配一侧图片，开启后会在一侧匹配失败时尝试匹配另一侧（常适用于匹配失败重新滚动到匹配失败位置时，如果关闭，必须再次向匹配方向进行滚动操作，但可能存在错误匹配导致拼接错误的情况）',
     'settings.systemSettings.scrollScreenshotSettings.imageFeatureThreshold': '图片特征阈值',
     'settings.systemSettings.scrollScreenshotSettings.imageFeatureThreshold.tip':
         '值越大，选取特征点的要求越高，采用 FAST 算法（https://en.wikipedia.org/wiki/Features_from_accelerated_segment_test）',
@@ -207,5 +211,7 @@ export const settings = {
         '仅针对白名单中的程序',
     'settings.systemSettings.screenshotSettings.tryGetElementByFocus.always': '保持启用',
     'settings.systemSettings.screenshotSettings.ocrModel': 'OCR 模型',
-    'settings.systemSettings.screenshotSettings.ocrModel.paddleOcr': 'Rapid OCR',
+    'settings.systemSettings.screenshotSettings.ocrModel.rapidOcrV4': 'Rapid OCR V4',
+    'settings.systemSettings.screenshotSettings.ocrModel.rapidOcrV5': 'Rapid OCR V5',
+    'settings.systemSettings.screenshotSettings.ocrDetectAngle': 'OCR 检测角度',
 };

--- a/src/utils/zIndex.ts
+++ b/src/utils/zIndex.ts
@@ -51,8 +51,12 @@ export const zIndexs = {
     // FullscreenDraw 全屏截图窗口 BEGIN
     /** 全屏截图绘制图层 */
     FullScreenDraw_DrawLayer: 0,
+    /** 全屏截图绘制工具栏 */
+    FullScreenDraw_Toolbar: 205,
     /** 全屏截图绘制图层 */
-    FullScreenDraw_LayoutMenu: 1,
+    FullScreenDraw_LayoutMenu: 207,
+    /** 全屏截图绘制工具栏 hover 状态 */
+    FullScreenDraw_ToolbarHover: 208,
     // FullscreenDraw 全屏截图窗口 END
 
     // VideoRecord 视频录制窗口 BEGIN


### PR DESCRIPTION
1. 滚动截图优化（截图、识别分开进行，提高快速滚动时的成功率）
2. 滚动截图默认只匹配一个方向（当匹配失败时，需要回到匹配失败处向截图方向再次滚动才能匹配，可在 系统设置-滚动截图 打开）
3. 默认 OCR 模型回退到 V4（可在 系统设置-截图 切换回 V5）
4. OCR 默认关闭角度检测（可在 系统设置-截图 打开）
5. 绘图工具支持绘制后自动回退到选择状态（不锁定工具，可在 功能设置-截图-锁定绘制工具 启用）
6. 修复全屏画布使用序列号后无法点击工具栏
7. 修复选择窗口元素时某些元素可能超出窗口范围