### PR TITLE
fix: 修复 OCR 划选文本可能选取到取色器内容

### DIFF
--- a/src/app/draw/components/colorPicker/index.tsx
+++ b/src/app/draw/components/colorPicker/index.tsx
@@ -908,6 +908,12 @@ const ColorPickerCore: React.FC<{
                     .color-picker-content-text {
                         text-align: center;
                     }
+
+                    .color-picker-content-text,
+                    .color-picker-content-color {
+                        user-select: none;
+                        pointer-events: none;
+                    }
                 `}
             </style>
         </div>


### PR DESCRIPTION
1. 修复 OCR 划选文本可能选取到取色器内容