### PR TITLE
fix: 修复编辑箭头时切换选择工具无法选中元素

### DIFF
--- a/src/app/fullScreenDraw/components/drawCore/index.tsx
+++ b/src/app/fullScreenDraw/components/drawCore/index.tsx
@@ -535,6 +535,7 @@ const DrawCoreComponent: React.FC<{
                         selectionElement: null,
                         selectedElementIds: {},
                         selectedGroupIds: {},
+                        multiElement: null,
                     },
                     captureUpdate: 'NEVER',
                 });


### PR DESCRIPTION
1. 修复编辑箭头时切换选择工具无法选中元素