### PR TITLE
fix: 修复全屏画布切换鼠标穿透后工具状态未保存

### DIFF
--- a/src/pages/fullScreenDraw/components/toolbar/index.tsx
+++ b/src/pages/fullScreenDraw/components/toolbar/index.tsx
@@ -211,7 +211,8 @@ export const FullScreenDrawToolbar: React.FC<{
 				case DrawState.MouseThrough:
 					drawCoreAction?.setActiveTool(
 						{
-							type: "selection",
+							type: "laser",
+							locked: true,
 						},
 						undefined,
 						next,


### PR DESCRIPTION
1. 修复全屏画布切换鼠标穿透后工具状态未保存