### PR TITLE
fix: OCR 识别时忽略绘制内容

### DIFF
--- a/src/pages/draw/actions.ts
+++ b/src/pages/draw/actions.ts
@@ -519,6 +519,8 @@ export const handleOcrDetect = async (
 		imageLayerAction,
 		drawLayerAction,
 		ignoreStyle,
+		true,
+		INIT_CONTAINER_KEY,
 	);
 	if (!imageCanvas) {
 		return;


### PR DESCRIPTION
1. OCR 识别时忽略绘制内容