### PR TITLE
feat: 禁用 Windows 下截图窗口的显示动画

### DIFF
--- a/src-tauri/src-crates/tauri-commands/screenshot/src/lib.rs
+++ b/src-tauri/src-crates/tauri-commands/screenshot/src/lib.rs
@@ -623,6 +623,32 @@ pub async fn create_draw_window(app: tauri::AppHandle) {
     .build()
     .unwrap();
 
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::Foundation::HWND;
+        use windows::Win32::Graphics::Dwm::{
+            DWMWA_TRANSITIONS_FORCEDISABLED, DwmSetWindowAttribute,
+        };
+
+        let window_hwnd = window.hwnd().unwrap();
+
+        // 禁用窗口动画
+        unsafe {
+            let disable_transitions: i32 = 1;
+            match DwmSetWindowAttribute(
+                HWND(window_hwnd.0),
+                DWMWA_TRANSITIONS_FORCEDISABLED,
+                &disable_transitions as *const _ as *const _,
+                std::mem::size_of::<i32>() as u32,
+            ) {
+                Ok(_) => (),
+                Err(_) => {
+                    log::error!("[create_draw_window] Failed to disable window transitions");
+                }
+            }
+        }
+    }
+
     window.hide().unwrap();
 }
 

--- a/src/pages/draw/page.tsx
+++ b/src/pages/draw/page.tsx
@@ -427,7 +427,6 @@ const DrawPageCore: React.FC<{
 				appError("[DrawPageCore] listenKeyStart error", error);
 			});
 
-			setDrawWindowStyle();
 			appWindow.setFocus();
 		},
 		[getScreenshotType],

--- a/src/pages/fixedContent/components/fixedContentCore/index.tsx
+++ b/src/pages/fixedContent/components/fixedContentCore/index.tsx
@@ -992,8 +992,6 @@ const FixedContentCoreInner: React.FC<{
 			return;
 		}
 
-		setDrawWindowStyle();
-
 		if (originWindowSizeAndPositionRef.current) {
 			switchThumbnailAnimationRef.current.update({
 				width: originWindowSizeAndPositionRef.current.size.width,
@@ -1407,8 +1405,6 @@ const FixedContentCoreInner: React.FC<{
 			if (targetScale === scaleRef.current.x) {
 				return;
 			}
-
-			setDrawWindowStyle();
 
 			// 计算新的窗口尺寸
 			const { width: newWidth, height: newHeight } =

--- a/src/pages/fixedContent/page.tsx
+++ b/src/pages/fixedContent/page.tsx
@@ -259,7 +259,6 @@ export const FixedContentPage: React.FC = () => {
 					max_y: windowY + windowHeight,
 				});
 				showWindow();
-				setDrawWindowStyle();
 			} else {
 				await appWindow.close();
 			}


### PR DESCRIPTION
1. 禁用 Windows 下截图窗口的显示动画