### PR TITLE
fix: 修复无法复制截图翻译的文本

### DIFF
--- a/src/pages/draw/page.tsx
+++ b/src/pages/draw/page.tsx
@@ -1168,7 +1168,11 @@ const DrawPageCore: React.FC<{
 				ocrResult?.ocrResultType === OcrResultType.VisionModelHtml ||
 				ocrResult?.ocrResultType === OcrResultType.VisionModelMarkdown)
 		) {
-			if (ocrResult && ocrResult.ocrResultType === OcrResultType.Ocr) {
+			if (
+				ocrResult &&
+				(ocrResult.ocrResultType === OcrResultType.Ocr ||
+					ocrResult.ocrResultType === OcrResultType.Translated)
+			) {
 				writeTextToClipboard(covertOcrResultToText(ocrResult.result));
 			} else if (
 				ocrResult &&


### PR DESCRIPTION
1. 修复无法复制截图翻译的文本